### PR TITLE
Correct error in orbit.model find_all example

### DIFF
--- a/doc/us/reference.md
+++ b/doc/us/reference.md
@@ -171,7 +171,7 @@ matches *condition*; *args* can determine the order (args.order), specify which 
 (args.fields, default is all of them), limit the number of returned rows (args.count), return only
 distinct rows (args.distinct), and inject fields from other tables (args.inject)
 
-Example: `books:find_first("author = ? and year_pub > ?", { "John Doe", 1995, order = "year_pub asc", count = 5, fields = { "id", "title" } })`
+Example: `books:find_all("author = ? and year_pub > ?", { "John Doe", 1995, order = "year_pub asc", count = 5, fields = { "id", "title" } })`
 
 **a\_model:new([*tab*])** - creates a fresh instance of the model, optionally using *tab* as initial
 values


### PR DESCRIPTION
Example should reference the find_all method, not find_first.
