### PR TITLE
transform require directives since wsapi not used clause module anymore

### DIFF
--- a/src/orbit.lua
+++ b/src/orbit.lua
@@ -1,6 +1,7 @@
-require "wsapi.request"
-require "wsapi.response"
-require "wsapi.util"
+local wsapi    = require "wsapi"
+wsapi.request  = require "wsapi.request"
+wsapi.response = require "wsapi.response"
+wsapi.util     = require "wsapi.util"
 
 local _G, setfenv = _G, setfenv
 module("orbit")

--- a/src/orbit/cache.lua
+++ b/src/orbit/cache.lua
@@ -1,5 +1,4 @@
-
-require "lfs"
+local lfs = require "lfs"
 
 module("orbit.cache", package.seeall)
 

--- a/src/orbit/model.lua
+++ b/src/orbit/model.lua
@@ -1,5 +1,5 @@
-require "lpeg"
-require "re"
+local lpeg = require "lpeg"
+local re   = require "re"
 
 module("orbit.model", package.seeall)
 

--- a/src/orbit/ophandler.lua
+++ b/src/orbit/ophandler.lua
@@ -5,8 +5,9 @@
 --
 -----------------------------------------------------------------------------
 
-require "wsapi.xavante"
-require "wsapi.common"
+local   wsapi = require ("wsapi")
+wsapi.xavante = require "wsapi.xavante"
+wsapi.common  = require "wsapi.common"
 
 module ("orbit.ophandler", package.seeall)
 


### PR DESCRIPTION
wsapi don't use module() anymore

lua 
Lua 5.1.4  Copyright (C) 1994-2008 Lua.org, PUC-Rio

> require "orbit"
> /usr/share/lua/5.1/orbit.lua:459: attempt to index global 'wsapi' (a nil value)
> stack traceback:
>     /usr/share/lua/5.1/orbit.lua:459: in main chunk
>     [C]: in function 'require'
>     stdin:1: in main chunk
>     [C]: ?
